### PR TITLE
Include the year 2024 as a tag for sorting

### DIFF
--- a/blog/2024-07-15-welcome/cilium-eks-sveltos.md
+++ b/blog/2024-07-15-welcome/cilium-eks-sveltos.md
@@ -4,7 +4,7 @@ title: Cilium on EKS with Sveltos
 authors: [egrosdou01]
 date: 2024-07-15
 image: ./cilium_sveltos_eks.jpg
-tags: [cilium,open-source,kubernetes,gitops,devops]
+tags: [cilium,open-source,kubernetes,gitops,devops,"2024"]
 ---
 
 ## Introduction

--- a/blog/2024-07-18-rke2-cilium/cilium-cluster-mesh-rke2.md
+++ b/blog/2024-07-18-rke2-cilium/cilium-cluster-mesh-rke2.md
@@ -3,7 +3,7 @@ slug: cilium-cluster-mesh-rke2
 title: Cilium Cluster Mesh on RKE2
 authors: [egrosdou01]
 date: 2024-07-18
-tags: [cilium,rke2,open-source,kubernetes,gitops,devops]
+tags: [cilium,rke2,open-source,kubernetes,gitops,devops,"2024"]
 ---
 
 ## Introduction

--- a/blog/2024-07-26-rancher-rke2-azure/rancher-rke2-cilium-azure.md
+++ b/blog/2024-07-26-rancher-rke2-azure/rancher-rke2-cilium-azure.md
@@ -3,7 +3,7 @@ slug: rancher-rke2-cilium-azure
 title: Rancher RKE2 Cluster on Azure
 authors: [egrosdou01]
 date: 2024-07-26
-tags: [rancher,cilium,rke2,open-source,kubernetes,gitops,devops,azure]
+tags: [rancher,cilium,rke2,open-source,kubernetes,gitops,devops,azure,"2024"]
 image: ./Rancher_RKE2_Cilium_Azure.jpg
 ---
 

--- a/blog/2024-08-10-sveltos-dynamic-templating/sveltos_dynamic_templating.md
+++ b/blog/2024-08-10-sveltos-dynamic-templating/sveltos_dynamic_templating.md
@@ -4,7 +4,7 @@ title: "Sveltos Templating: Cilium Cluster Mesh in One Run"
 authors: [egrosdou01]
 date: 2024-08-10
 image: ./Sveltos_Templating_Cilium.jpg
-tags: [sveltos,cilium,open-source,kubernetes,gitops,devops]
+tags: [sveltos,cilium,open-source,kubernetes,gitops,devops,"2024"]
 ---
 
 ## Introduction

--- a/blog/2024-08-21-opentofu-rke2-cilium-azure/opentofu-rke2-cilium-azure.md
+++ b/blog/2024-08-21-opentofu-rke2-cilium-azure/opentofu-rke2-cilium-azure.md
@@ -3,7 +3,7 @@ slug: opentofu-rke2-cilium-azure.md
 title: "OpenTofu: RKE2 Cluster with Cilium on Azure"
 authors: [egrosdou01]
 date: 2024-08-21
-tags: [opentofu,cilium,rke2,open-source,kubernetes,gitops,devops]
+tags: [opentofu,cilium,rke2,open-source,kubernetes,gitops,devops,"2024"]
 ---
 
 ## Introduction

--- a/blog/tags.yml
+++ b/blog/tags.yml
@@ -1,3 +1,7 @@
+"2024":
+  label: "2024"
+  permalink: /2024
+  description: The year the post went online
 hello:
   label: Hello
   permalink: /hello


### PR DESCRIPTION
- Include year 2024 as a tag
- Update the blog posts to include the year they got published